### PR TITLE
APIS-3672

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -2,6 +2,7 @@
 @import "partials/banner-messages.scss";
 @import "partials/side-nav.scss";
 @import "partials/sandbox.scss";
+@import "partials/forms.scss";
 // Ad-hoc fixes
 @import "ad-hoc";
 

--- a/app/assets/stylesheets/partials/forms.scss
+++ b/app/assets/stylesheets/partials/forms.scss
@@ -1,0 +1,7 @@
+@media(min-width: 641px) {
+  .form-control,
+  input[type="text"],
+  input[type="password"]{
+    width: 75%;
+  }
+}


### PR DESCRIPTION
Override styles for text and password fields to make them 75% width which will ensure input fields are not truncated when zoomed in.