### PR TITLE
APIS-4442 - Fixed crash during application startup.

### DIFF
--- a/app/connectors/ApiSubscriptionFieldsConnector.scala
+++ b/app/connectors/ApiSubscriptionFieldsConnector.scala
@@ -41,10 +41,6 @@ abstract class ApiSubscriptionFieldsConnector(private val environment: Environme
   val http: HttpClient = {
     if (useProxy) {
       Logger.debug(s"Using Proxy Server ($environment)")
-      proxiedHttpClient.wsProxyServer.map(
-        proxyServer =>
-          Logger.debug(s"Proxy Server username '${proxyServer.principal.getOrElse("")}' and host ${proxyServer.host}")
-      )
       proxiedHttpClient.withAuthorization(bearerToken)
     } else {
         Logger.debug(s"Not using Proxy Server ($environment)")

--- a/test/unit/connectors/ApiSubscriptionFieldsBaseConnectorSpec.scala
+++ b/test/unit/connectors/ApiSubscriptionFieldsBaseConnectorSpec.scala
@@ -50,7 +50,13 @@ class ApiSubscriptionFieldsBaseConnectorSpec extends BaseConnectorSpec {
 
   class ApiSubscriptionFieldsTestConnector(val httpClient: HttpClient,
                                            val proxiedHttpClient: ProxiedHttpClient)(implicit val ec: ExecutionContext)
-    extends ApiSubscriptionFieldsConnector(Environment.SANDBOX, useProxy = false, bearerToken = "", serviceBaseUrl = "") {
+    extends ApiSubscriptionFieldsConnector(
+      Environment.SANDBOX,
+      useProxy = false,
+      bearerToken = "",
+      serviceBaseUrl = "",
+      httpClient = httpClient,
+      proxiedHttpClient = proxiedHttpClient) {
   }
 
   "fetchFieldValues" should {


### PR DESCRIPTION
All parameters are injected into ApiSubscriptionFieldsConnector.
- No longer logs and uses the proxiedHttpClient during construction as this was causing a exception during application startup.