### PR TITLE
APIS-4483 - Improved efficiency of loading subscriptions page

### DIFF
--- a/app/service/SubscriptionFieldsService.scala
+++ b/app/service/SubscriptionFieldsService.scala
@@ -34,11 +34,14 @@ class SubscriptionFieldsService @Inject()(connectorsWrapper: ConnectorsWrapper)(
       defs.map(field => field.withValue(fieldValues.get(field.name)))
     }
 
-    def fetchFieldsValues(defs: Seq[SubscriptionField])(implicit hc: HeaderCarrier): Future[Seq[SubscriptionField]] = {
-      for {
-        maybeValues <- connector.fetchFieldValues(application.clientId, apiContext, apiVersion)
-      } yield maybeValues.fold(defs) { response =>
-        addValuesToDefinitions(defs, response.fields)
+    def fetchFieldsValues(fieldDefinitions: Seq[SubscriptionField])(implicit hc: HeaderCarrier): Future[Seq[SubscriptionField]] = {
+      if (fieldDefinitions.isEmpty) Future.successful(Seq.empty)
+      else {
+        for {
+          maybeValues <- connector.fetchFieldValues(application.clientId, apiContext, apiVersion)
+        } yield maybeValues.fold(fieldDefinitions) { response =>
+          addValuesToDefinitions(fieldDefinitions, response.fields)
+        }
       }
     }
 


### PR DESCRIPTION
It no longer tries to load the api subscription values if there is no
api subscription definitions for an api version.