### PR TITLE
APIS-4386 - Fixed bug with uplifting an app and name validation

### DIFF
--- a/app/connectors/ThirdPartyApplicationConnector.scala
+++ b/app/connectors/ThirdPartyApplicationConnector.scala
@@ -177,8 +177,8 @@ abstract class ThirdPartyApplicationConnector(config: ApplicationConfig, metrics
     } recover recovery
   }
 
-  def validateName(name: String)(implicit hc: HeaderCarrier): Future[ApplicationNameValidation] = {
-    val body = ApplicationNameValidationRequest(name)
+  def validateName(name: String, selfApplicationId: Option[String])(implicit hc: HeaderCarrier): Future[ApplicationNameValidation] = {
+    val body = ApplicationNameValidationRequest(name, selfApplicationId)
 
     retry {
       http.POST[ApplicationNameValidationRequest, ApplicationNameValidationResult](s"$serviceBaseUrl/application/name/validate", body) map {

--- a/app/controllers/ApplicationCheck.scala
+++ b/app/controllers/ApplicationCheck.scala
@@ -16,6 +16,8 @@
 
 package controllers
 
+import java.util.UUID
+
 import config.{ApplicationConfig, ErrorHandler}
 import controllers.FormKeys._
 import domain.Capabilities.SupportsAppChecks
@@ -134,7 +136,7 @@ class ApplicationCheck @Inject()(val applicationService: ApplicationService,
     }
 
     def withValidForm(form: NameForm): Future[Result] = {
-      applicationService.isApplicationNameValid(form.applicationName, app.deployedTo)
+      applicationService.isApplicationNameValid(form.applicationName, app.deployedTo, Some(app.id))
         .flatMap({
           case Valid =>
             val information = app.checkInformation.getOrElse(CheckInformation())

--- a/app/controllers/ManageApplications.scala
+++ b/app/controllers/ManageApplications.scala
@@ -67,7 +67,7 @@ class ManageApplications @Inject()(val applicationService: ApplicationService,
 
       val environment = formThatPassesSimpleValidation.environment.flatMap(Environment.from).getOrElse(Environment.SANDBOX)
 
-      applicationService.isApplicationNameValid(formThatPassesSimpleValidation.applicationName, environment).flatMap {
+      applicationService.isApplicationNameValid(formThatPassesSimpleValidation.applicationName, environment, selfApplicationId = None).flatMap {
         case Valid => {
           applicationService
             .createForUser(CreateApplicationRequest.from(loggedIn, formThatPassesSimpleValidation))

--- a/app/domain/ApplicationNameValidationJson.scala
+++ b/app/domain/ApplicationNameValidationJson.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{Json, OFormat}
 
 object ApplicationNameValidationJson {
 
-  case class ApplicationNameValidationRequest(applicationName: String)
+  case class ApplicationNameValidationRequest(applicationName: String, selfApplicationId: Option[String])
 
   object ApplicationNameValidationRequest {
     implicit val format: OFormat[ApplicationNameValidationRequest] = Json.format[ApplicationNameValidationRequest]

--- a/app/service/ApplicationService.scala
+++ b/app/service/ApplicationService.scala
@@ -16,6 +16,8 @@
 
 package service
 
+import java.util.UUID
+
 import config.ApplicationConfig
 import connectors._
 import domain.APIStatus._
@@ -252,10 +254,11 @@ class ApplicationService @Inject()(connectorWrapper: ConnectorsWrapper,
     } yield ticketResponse
   }
 
-  def isApplicationNameValid(name: String, environment: Environment)(implicit hc: HeaderCarrier): Future[ApplicationNameValidation] = {
+  def isApplicationNameValid(name: String, environment: Environment, selfApplicationId: Option[String])
+                            (implicit hc: HeaderCarrier): Future[ApplicationNameValidation] = {
     environment match {
-      case PRODUCTION => connectorWrapper.productionApplicationConnector.validateName(name)
-      case SANDBOX => connectorWrapper.sandboxApplicationConnector.validateName(name)
+      case PRODUCTION => connectorWrapper.productionApplicationConnector.validateName(name, selfApplicationId)
+      case SANDBOX => connectorWrapper.sandboxApplicationConnector.validateName(name, selfApplicationId)
     }
   }
 

--- a/test/unit/controllers/ApplicationCheckSpec.scala
+++ b/test/unit/controllers/ApplicationCheckSpec.scala
@@ -116,7 +116,7 @@ class ApplicationCheckSpec extends BaseControllerSpec with SubscriptionTestHelpe
     given(underTest.apiSubscriptionsHelper.fetchAllSubscriptions(any[Application], any[DeveloperSession])(any[HeaderCarrier]))
       .willReturn(successful(Some(SubscriptionData(Role.ADMINISTRATOR, application, Some(groupedSubs), hasSubscriptions = true))))
 
-    given(underTest.applicationService.isApplicationNameValid(any(), any())(any[HeaderCarrier]))
+    given(underTest.applicationService.isApplicationNameValid(any(), any(), any())(any[HeaderCarrier]))
       .willReturn(Future.successful(Valid))
 
     val sessionParams: Seq[(String, String)] = Seq("csrfToken" -> fakeApplication.injector.instanceOf[TokenProvider].generateToken)
@@ -722,7 +722,7 @@ class ApplicationCheckSpec extends BaseControllerSpec with SubscriptionTestHelpe
     "Validation failure name contains HMRC action" in new Setup {
       givenTheApplicationExists()
 
-      given(underTest.applicationService.isApplicationNameValid(any(), any())(any[HeaderCarrier]))
+      given(underTest.applicationService.isApplicationNameValid(any(), any(), any())(any[HeaderCarrier]))
         .willReturn(Future.successful(Invalid.invalidName))
 
       private val applicationName = "Blacklisted HMRC"
@@ -735,13 +735,14 @@ class ApplicationCheckSpec extends BaseControllerSpec with SubscriptionTestHelpe
 
       bodyOf(result) should include("Choose an application name that does not include HMRC")
 
-      verify(underTest.applicationService).isApplicationNameValid(mockEq(applicationName), mockEq(Environment.PRODUCTION))(any[HeaderCarrier])
+      verify(underTest.applicationService)
+        .isApplicationNameValid(mockEq(applicationName), mockEq(Environment.PRODUCTION), mockEq(Some(appId)))(any[HeaderCarrier])
     }
 
     "Validation failure when duplicate name" in new Setup {
       givenTheApplicationExists()
 
-      given(underTest.applicationService.isApplicationNameValid(any(), any())(any[HeaderCarrier]))
+      given(underTest.applicationService.isApplicationNameValid(any(), any(), any())(any[HeaderCarrier]))
         .willReturn(Future.successful(Invalid.duplicateName))
 
       private val applicationName = "Duplicate Name"
@@ -754,7 +755,8 @@ class ApplicationCheckSpec extends BaseControllerSpec with SubscriptionTestHelpe
 
       bodyOf(result) should include("Choose an application name that is not already registered on the Developer Hub")
 
-      verify(underTest.applicationService).isApplicationNameValid(mockEq(applicationName), mockEq(Environment.PRODUCTION))(any[HeaderCarrier])
+      verify(underTest.applicationService)
+        .isApplicationNameValid(mockEq(applicationName), mockEq(Environment.PRODUCTION), mockEq(Some(appId)))(any[HeaderCarrier])
     }
 
     "return forbidden when accessing the action without being an admin" in new Setup {

--- a/test/unit/controllers/ManageApplicationsSpec.scala
+++ b/test/unit/controllers/ManageApplicationsSpec.scala
@@ -86,7 +86,7 @@ class ManageApplicationsSpec
     given(underTest.applicationService.fetchByApplicationId(mockEq(application.id))(any[HeaderCarrier]))
       .willReturn(successful(application))
 
-    given(underTest.applicationService.isApplicationNameValid(any(),any())(any[HeaderCarrier]))
+    given(underTest.applicationService.isApplicationNameValid(any(), any(), any())(any[HeaderCarrier]))
       .willReturn(successful(Valid))
 
     private val sessionParams = Seq("csrfToken" -> fakeApplication.injector.instanceOf[TokenProvider].generateToken)
@@ -194,7 +194,7 @@ class ManageApplicationsSpec
       "and it contains HMRC it shows an error page and lets you re-submit the name" in new Setup {
         private val invalidApplicationName = "invalidApplicationName"
 
-        given(underTest.applicationService.isApplicationNameValid(any(),any())(any[HeaderCarrier]))
+        given(underTest.applicationService.isApplicationNameValid(any(), any(), any())(any[HeaderCarrier]))
           .willReturn(Invalid(invalidName = true, duplicateName = false))
 
         private val request = utils.CSRFTokenHelper.CSRFRequestHeader(loggedInRequest)
@@ -213,13 +213,13 @@ class ManageApplicationsSpec
           .createForUser(any[CreateApplicationRequest])(any[HeaderCarrier])
 
         verify(underTest.applicationService)
-          .isApplicationNameValid(mockEq(invalidApplicationName), mockEq(Environment.SANDBOX))(any[HeaderCarrier])
+          .isApplicationNameValid(mockEq(invalidApplicationName), mockEq(Environment.SANDBOX), any())(any[HeaderCarrier])
       }
 
       "and it is duplicate it shows an error page and lets you re-submit the name" in new Setup {
         private val applicationName = "duplicate name"
 
-        given(underTest.applicationService.isApplicationNameValid(any(),any())(any[HeaderCarrier]))
+        given(underTest.applicationService.isApplicationNameValid(any(), any(), any())(any[HeaderCarrier]))
           .willReturn(Invalid(invalidName = false, duplicateName = true))
 
         private val request = utils.CSRFTokenHelper.CSRFRequestHeader(loggedInRequest)
@@ -238,7 +238,7 @@ class ManageApplicationsSpec
           .createForUser(any[CreateApplicationRequest])(any[HeaderCarrier])
 
         verify(underTest.applicationService)
-          .isApplicationNameValid(mockEq(applicationName), mockEq(Environment.SANDBOX))(any[HeaderCarrier])
+          .isApplicationNameValid(mockEq(applicationName), mockEq(Environment.SANDBOX), any())(any[HeaderCarrier])
       }
 
     }

--- a/test/unit/service/ApplicationServiceSpec.scala
+++ b/test/unit/service/ApplicationServiceSpec.scala
@@ -806,28 +806,30 @@ class ApplicationServiceSpec extends UnitSpec with MockitoSugar with ScalaFuture
   "validate application name" should {
     "call the application connector validate method in sandbox" in new Setup {
       private val applicationName = "applicationName"
+      private val applicationId = UUID.randomUUID().toString
 
-      given(mockSandboxApplicationConnector.validateName(any())(any[HeaderCarrier]))
+      given(mockSandboxApplicationConnector.validateName(any(), any())(any[HeaderCarrier]))
         .willReturn(Valid)
 
-      val result = await (service.isApplicationNameValid(applicationName, Environment.SANDBOX))
+      val result = await (service.isApplicationNameValid(applicationName, Environment.SANDBOX, Some(applicationId)))
 
       result shouldBe Valid
 
-      verify(mockSandboxApplicationConnector).validateName(mockEq(applicationName))(mockEq(hc))
+      verify(mockSandboxApplicationConnector).validateName(mockEq(applicationName), mockEq(Some(applicationId)))(mockEq(hc))
     }
 
     "call the application connector validate method in production" in new Setup {
       private val applicationName = "applicationName"
+      private val applicationId = UUID.randomUUID().toString
 
-      given(mockProductionApplicationConnector.validateName(any())(any[HeaderCarrier]))
+      given(mockProductionApplicationConnector.validateName(any(), any())(any[HeaderCarrier]))
         .willReturn(Valid)
 
-      val result = await (service.isApplicationNameValid(applicationName, Environment.PRODUCTION))
+      val result = await (service.isApplicationNameValid(applicationName, Environment.PRODUCTION, Some(applicationId)))
 
       result shouldBe Valid
 
-      verify(mockProductionApplicationConnector).validateName(mockEq(applicationName))(mockEq(hc))
+      verify(mockProductionApplicationConnector).validateName(mockEq(applicationName), mockEq(Some(applicationId)))(mockEq(hc))
     }
   }
 


### PR DESCRIPTION
APIS-4386 - Fixed bug when uplifting an app failed as it thought itself was a duplicate name.
- Now ignores itself when checking for a duplicate name