### PR TITLE
APIS-4535 - Whitespace on sandbox subscriptions page

### DIFF
--- a/app/views/subscriptions2.scala.html
+++ b/app/views/subscriptions2.scala.html
@@ -74,6 +74,9 @@
         }
     }
 
+    </br>
+    </br>
+
     <div>
         <a class="button" href="@routes.AddApplication.addApplicationSuccess(app.id, environment)">Add your application</a>
     </div>


### PR DESCRIPTION
Added whitespace between the sandbox subscriptions page and the 'add' button