### PR TITLE
APIS-4502 - Updated SDST email in Terms of Use

### DIFF
--- a/app/views/partials/termsOfUse.scala.html
+++ b/app/views/partials/termsOfUse.scala.html
@@ -91,7 +91,7 @@
     </section>
     <section>
         <h3 class="heading-medium">Data breaches</h3>
-        <p>If there’s a data breach or any other issue concerning customer data you must tell us immediately by emailing <a href="mailto:SDSTeam@@hmrc.gsi.gov.uk">SDSTeam@@hmrc.gsi.gov.uk</a>.</p>
+        <p>If there’s a data breach or any other issue concerning customer data you must tell us immediately by emailing <a href="mailto:SDSTeam@@hmrc.gov.co.uk">SDSTeam@@hmrc.gov.co.uk</a>.</p>
         <p>Under GDPR rules, you must also <a href="https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/personal-data-breaches/" target="_blank" rel="noopener noreferrer">notify ICO about certain types of personal data breach (opens in a new tab)</a>            within 72 hours of becoming aware of it.</p>
     </section>
     <section>


### PR DESCRIPTION
The text on the Terms of Use page is stored in a single place i.e. partials/termsOfUse.scala.html in the third-party-developer-frontend repo.

api-documentation-frontend calls the '/partials/terms-of-use' endpoint on third-party-developer-frontend to get the terms of use.