### PR TITLE
APIS-5678 Allow going back to 'Before you start' page

### DIFF
--- a/app/uk/gov/hmrc/apiplatform/modules/uplift/controllers/UpliftJourneyController.scala
+++ b/app/uk/gov/hmrc/apiplatform/modules/uplift/controllers/UpliftJourneyController.scala
@@ -84,6 +84,7 @@ class UpliftJourneyController @Inject() (val errorHandler: ErrorHandler,
                       flowService: GetProductionCredentialsFlowService,
                       sellResellOrDistributeSoftwareView: SellResellOrDistributeSoftwareView,
                       weWillCheckYourAnswersView: WeWillCheckYourAnswersView,
+                      beforeYouStartView: BeforeYouStartView,
                       upliftJourneySwitch: UpliftJourneySwitch)
                      (implicit val ec: ExecutionContext, val appConfig: ApplicationConfig)
   extends ApplicationController(mcc)
@@ -186,6 +187,10 @@ class UpliftJourneyController @Inject() (val errorHandler: ErrorHandler,
       }
     }
     sellResellOrDistributeForm.bindFromRequest.fold(handleInvalidForm, handleValidForm)
+  }
+
+  def beforeYouStart(sandboxAppId: ApplicationId): Action[AnyContent] = whenTeamMemberOnApp(sandboxAppId) { implicit request =>
+    Future(Ok(beforeYouStartView(sandboxAppId)))
   }
 
   def weWillCheckYourAnswers(sandboxAppId: ApplicationId): Action[AnyContent] = whenTeamMemberOnApp(sandboxAppId) { implicit request =>

--- a/app/uk/gov/hmrc/apiplatform/modules/uplift/views/BeforeYouStartView.scala.html
+++ b/app/uk/gov/hmrc/apiplatform/modules/uplift/views/BeforeYouStartView.scala.html
@@ -39,9 +39,9 @@
 
     <p class="govuk-body">We will ask you questions about your organisation and development practices.</p>
 
-    <p class="govuk-body">You can <a href="/api-documentation/docs/terms-of-use" class="govuk-link">review the questions before you start</a>.</p>
+    <p class="govuk-body">You can <a href="/api-documentation/docs/terms-of-use" class="govuk-link" target="_blank">review the questions before you start (opens in new tab)</a>.</p>
 
-    <p class="govuk-body">You will need the name and email address of a responsible individual in your organisation who is accountable for compliance with our <a href="/api-documentation/docs/terms-of-use" class="govuk-link">terms of use</a>.</p>
+    <p class="govuk-body">You will need the name and email address of a responsible individual in your organisation who is accountable for compliance with our <a href="/api-documentation/docs/terms-of-use" class="govuk-link" target="_blank">terms of use (opens in new tab)</a>.</p>
 
     <a class="govuk-button" href="@uk.gov.hmrc.apiplatform.modules.uplift.controllers.routes.UpliftJourneyController.weWillCheckYourAnswers(applicationId)">Continue</a>
 }

--- a/app/uk/gov/hmrc/thirdpartydeveloperfrontend/controllers/addapplication/AddApplication.scala
+++ b/app/uk/gov/hmrc/thirdpartydeveloperfrontend/controllers/addapplication/AddApplication.scala
@@ -103,7 +103,7 @@ class AddApplication @Inject() (
 
   def progressOnUpliftJourney(sandboxAppId: ApplicationId): Action[AnyContent] = loggedInAction { implicit request =>
     upliftJourneySwitch.performSwitch(
-      successful(Ok(beforeYouStartView(sandboxAppId))),        // new uplift path
+      successful(Redirect(uk.gov.hmrc.apiplatform.modules.uplift.controllers.routes.UpliftJourneyController.beforeYouStart(sandboxAppId))),        // new uplift path
       showConfirmSubscriptionsPage(sandboxAppId)(request)      // existing uplift path
     )
   }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -198,6 +198,7 @@ POST        /applications/:id/change-api-subscriptions                          
 GET         /applications/:id/sell-resell-or-distribute-your-software                                    uk.gov.hmrc.apiplatform.modules.uplift.controllers.UpliftJourneyController.sellResellOrDistributeYourSoftware(id: ApplicationId)
 POST        /applications/:id/sell-resell-or-distribute-your-software                                    uk.gov.hmrc.apiplatform.modules.uplift.controllers.UpliftJourneyController.sellResellOrDistributeYourSoftwareAction(id: ApplicationId)
 
+GET         /applications/:id/before-you-start                                                           uk.gov.hmrc.apiplatform.modules.uplift.controllers.UpliftJourneyController.beforeYouStart(id: ApplicationId)
 GET         /applications/:id/we-will-check-your-answers                                                 uk.gov.hmrc.apiplatform.modules.uplift.controllers.UpliftJourneyController.weWillCheckYourAnswers(id: ApplicationId)
 
 ->         /govuk-frontend       govuk.Routes

--- a/test/uk/gov/hmrc/modules/uplift/controllers/UpliftJourneyControllerSpec.scala
+++ b/test/uk/gov/hmrc/modules/uplift/controllers/UpliftJourneyControllerSpec.scala
@@ -72,6 +72,7 @@ class UpliftJourneyControllerSpec extends BaseControllerSpec
     val turnOffApisMasterView = app.injector.instanceOf[TurnOffApisMasterView]
     val sellResellOrDistributeSoftwareView = app.injector.instanceOf[SellResellOrDistributeSoftwareView]
     val weWillCheckYourAnswersView = app.injector.instanceOf[WeWillCheckYourAnswersView]
+    val beforeYouStartView = app.injector.instanceOf[BeforeYouStartView]
 
     val mockUpliftJourneyConfig = mock[UpliftJourneyConfig]
     val sr20UpliftJourneySwitchMock = new UpliftJourneySwitch(mockUpliftJourneyConfig)
@@ -90,6 +91,7 @@ class UpliftJourneyControllerSpec extends BaseControllerSpec
       GPCFlowServiceMock.aMock,
       sellResellOrDistributeSoftwareView,
       weWillCheckYourAnswersView,
+      beforeYouStartView,
       sr20UpliftJourneySwitchMock
     )
 
@@ -360,6 +362,19 @@ class UpliftJourneyControllerSpec extends BaseControllerSpec
       titleOf(result) shouldBe "We will check your answers - HMRC Developer Hub - GOV.UK"
 
       contentAsString(result) should include("We will check your answers")
+    }
+  }
+
+  "beforeYouStart" should {
+
+    "render the 'before you start' page" in new Setup {
+      private val result = controller.beforeYouStart(appId)(loggedInRequest.withCSRFToken)
+
+      status(result) shouldBe OK
+
+      titleOf(result) shouldBe "Before you start - HMRC Developer Hub - GOV.UK"
+
+      contentAsString(result) should include("Before you start")
     }
   }
 }

--- a/test/uk/gov/hmrc/thirdpartydeveloperfrontend/controllers/AddApplicationStartSpec.scala
+++ b/test/uk/gov/hmrc/thirdpartydeveloperfrontend/controllers/AddApplicationStartSpec.scala
@@ -192,14 +192,15 @@ class AddApplicationStartSpec
       when(flowServiceMock.resetFlow(*)).thenReturn(Future.successful(GetProductionCredentialsFlow("", None, None)))
 
       val summaries = sandboxAppSummaries.take(1)
+      val myAppId = summaries.head.id
       aUsersUplfitableAndNotUpliftableAppsReturns(summaries, summaries.map(_.id), List.empty)
 
       when(upliftJourneyConfigMock.status).thenReturn(On)
       
       private val result = underTest.addApplicationPrincipal()(loggedInRequest)
 
-      status(result) shouldBe OK
-      contentAsString(result) should include("Before you start")
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(s"/developer/applications/${myAppId.value}/before-you-start")
     }
 
     "return the uplift journey 'Which application do you want production credentials for?' page when the UpliftJourneyConfig returns On" +
@@ -254,6 +255,7 @@ class AddApplicationStartSpec
       when(flowServiceMock.resetFlow(*)).thenReturn(Future.successful(GetProductionCredentialsFlow("", None, None)))
 
       val summaries = sandboxAppSummaries.take(1)
+      val myAppId = summaries.head.id
       aUsersUplfitableAndNotUpliftableAppsReturns(summaries, summaries.map(_.id), List.empty)
 
       when(upliftJourneyConfigMock.status).thenReturn(OnDemand)
@@ -262,8 +264,8 @@ class AddApplicationStartSpec
 
       private val result = underTest.addApplicationPrincipal()(loggedInRequestWithFlag)
 
-      status(result) shouldBe OK
-      contentAsString(result) should include("Before you start")
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(s"/developer/applications/${myAppId.value}/before-you-start")
     }
 
     "return the add applications page when the UpliftJourneyConfig " +
@@ -288,6 +290,7 @@ class AddApplicationStartSpec
           when(flowServiceMock.resetFlow(*)).thenReturn(Future.successful(GetProductionCredentialsFlow("", None, None)))
 
           val summaries = sandboxAppSummaries.take(1)
+          val myAppId = summaries.head.id
           aUsersUplfitableAndNotUpliftableAppsReturns(summaries, summaries.map(_.id), List.empty)
 
           when(upliftJourneyConfigMock.status).thenReturn(On)
@@ -296,9 +299,9 @@ class AddApplicationStartSpec
 
           private val result = underTest.addApplicationPrincipal()(loggedInRequestWithFlag)
 
-          status(result) shouldBe OK
-          contentAsString(result) should include("Before you start")
-        }
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(s"/developer/applications/${myAppId.value}/before-you-start")
+       }
 
     "return to the login page when the user is not logged in" in new Setup {
       val request = FakeRequest()


### PR DESCRIPTION
Two fixes here:

1. Links on this page now open in a new tab
2. Previous page now redirects to here so can go back using the breadcrumb Back link on subsequent pages without getting the 'Confirm Form Resubmission' message