### PR TITLE
APIS-5766 Display page when link has expired

### DIFF
--- a/app/uk/gov/hmrc/apiplatform/modules/submissions/controllers/VerifyResponsibleIndividualController.scala
+++ b/app/uk/gov/hmrc/apiplatform/modules/submissions/controllers/VerifyResponsibleIndividualController.scala
@@ -77,7 +77,7 @@ class VerifyResponsibleIndividualController @Inject() (
 
   private val exec = ec
   private val ET = new EitherTHelper[Result] { implicit val ec: ExecutionContext = exec }
-  private val noRIVerificationRecordError = "This link has already been used to verify the responsible individual or has expired"
+  private val noRIVerificationRecordError = "This page has expired"
 
   def verifyPage(code: String) = Action.async { implicit request =>
     lazy val success = (riVerification: ResponsibleIndividualVerification) => 

--- a/app/uk/gov/hmrc/apiplatform/modules/submissions/views/ResponsibleIndividualErrorView.scala.html
+++ b/app/uk/gov/hmrc/apiplatform/modules/submissions/views/ResponsibleIndividualErrorView.scala.html
@@ -37,8 +37,8 @@
 ) {
 
   <h1 class="govuk-panel__title">
-    An error has occurred while trying to verify the responsible individual
+    @errorMessage
   </h1>
 
-  <p class="govuk-body">@errorMessage</p>
+  <p class="govuk-body">Talk to the admin responsible for your software on the Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/apiplatform/modules/submissions/views/ResponsibleIndividualErrorView.scala.html
+++ b/app/uk/gov/hmrc/apiplatform/modules/submissions/views/ResponsibleIndividualErrorView.scala.html
@@ -40,5 +40,5 @@
     @errorMessage
   </h1>
 
-  <p class="govuk-body">Talk to the admin responsible for your software on the Developer Hub</p>
+  <p class="govuk-body">Talk to the admin responsible for your software on the Developer Hub.</p>
 }

--- a/app/uk/gov/hmrc/apiplatform/modules/submissions/views/VerifyResponsibleIndividualView.scala.html
+++ b/app/uk/gov/hmrc/apiplatform/modules/submissions/views/VerifyResponsibleIndividualView.scala.html
@@ -36,23 +36,28 @@
   ),
   developerSession = None
 ) {
-  <h1 class="govuk-heading-l">Are you the individual responsible for this software on the HMRC Developer Hub?</h1>
-
-  <p class="govuk-body govuk-!-font-size-27 govuk-!-margin-top-4 govuk-!-margin-bottom-6">@model.appName</p>
-
-  <p class="govuk-body">As the responsible individual you:</p>
-
-  <ul class="govuk-list govuk-list--bullet">
-    <li>ensure your software conforms to the <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="/api-documentation/docs/terms-of-use">terms of use (opens in new tab)</a></li>
-    <li>understand the <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="/api-documentation/docs/terms-of-use/not-meeting-terms-of-use">consequences of not conforming to the terms of use (opens in new tab)</a></li>
-  </ul>
-
   @errorSummary2(form)
 
   @helper.form(action = uk.gov.hmrc.apiplatform.modules.submissions.controllers.routes.VerifyResponsibleIndividualController.verifyAction(model.code), 'class -> "form") {
     @helper.CSRF.formField
 
-    <div class="govuk-form-group">
+    <div class="govuk-form-group @if(form.errors("verified").nonEmpty) {govuk-form-group--error}">
+
+      <h1 class="govuk-heading-l">Are you the individual responsible for this software on the HMRC Developer Hub?</h1>
+
+      <p class="govuk-body govuk-!-font-size-27 govuk-!-margin-top-4 govuk-!-margin-bottom-6">@model.appName</p>
+
+      <p class="govuk-body">As the responsible individual you:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>ensure your software conforms to the <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="/api-documentation/docs/terms-of-use">terms of use (opens in new tab)</a></li>
+        <li>understand the <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="/api-documentation/docs/terms-of-use/not-meeting-terms-of-use">consequences of not conforming to the terms of use (opens in new tab)</a></li>
+      </ul>
+
+      <p id="verified-error" class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error: </span> @fieldError2(form.errors, "verified", form.error("submissionError").isEmpty)
+      </p>
+
       <div class="govuk-radios govuk-radios--inline">
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="yes" type="radio" name="verified" value="yes">


### PR DESCRIPTION
Display page when link has expired/already been used.  Also improve the error messages on the verify RI page when nothing selected.