### PR TITLE
API-6492 Change canUseNewUpliftJourney OnDemand to default to new journey

### DIFF
--- a/app/uk/gov/hmrc/apiplatform/modules/uplift/controllers/UpliftJourneyController.scala
+++ b/app/uk/gov/hmrc/apiplatform/modules/uplift/controllers/UpliftJourneyController.scala
@@ -40,7 +40,7 @@ import uk.gov.hmrc.apiplatform.modules.submissions.services.SubmissionService
 import uk.gov.hmrc.apiplatform.modules.uplift.domain.models.ApiSubscriptions
 import uk.gov.hmrc.apiplatform.modules.uplift.services.{GetProductionCredentialsFlowService, UpliftJourneyService}
 import uk.gov.hmrc.apiplatform.modules.uplift.views.html._
-import uk.gov.hmrc.thirdpartydeveloperfrontend.config.{ApplicationConfig, ErrorHandler, On, OnDemand, UpliftJourneyConfig}
+import uk.gov.hmrc.thirdpartydeveloperfrontend.config.{ApplicationConfig, ErrorHandler, Off, OnDemand, UpliftJourneyConfig}
 import uk.gov.hmrc.thirdpartydeveloperfrontend.connectors.ApmConnector
 import uk.gov.hmrc.thirdpartydeveloperfrontend.controllers.checkpages.{CanUseCheckActions, DummySubscriptionsForm}
 import uk.gov.hmrc.thirdpartydeveloperfrontend.controllers.{APISubscriptions, ApplicationController, FormKeys, checkpages}
@@ -263,16 +263,16 @@ class UpliftJourneyController @Inject() (
 @Singleton
 class UpliftJourneySwitch @Inject() (upliftJourneyConfig: UpliftJourneyConfig) {
 
-  private def upliftJourneyTurnedOnInRequestHeader(implicit request: Request[_]): Boolean =
-    request.headers.get("useNewUpliftJourney").fold(false) { setting =>
+  private def upliftJourneyUseOldJourneyInRequestHeader(implicit request: Request[_]): Boolean =
+    request.headers.get("useOldUpliftJourney").fold(false) { setting =>
       Try(setting.toBoolean).getOrElse(false)
     }
 
   def shouldUseV2(implicit request: Request[_]): Boolean =
     upliftJourneyConfig.status match {
-      case On                                               => true
-      case OnDemand if upliftJourneyTurnedOnInRequestHeader => true
-      case _                                                => false
+      case Off                                                   => false
+      case OnDemand if upliftJourneyUseOldJourneyInRequestHeader => false
+      case _                                                     => true
     }
 
   def performSwitch(newUpliftPath: => Future[Result], existingUpliftPath: => Future[Result])(implicit request: Request[_]): Future[Result] =

--- a/test/uk/gov/hmrc/thirdpartydeveloperfrontend/controllers/AddApplicationProductionSwitchSpec.scala
+++ b/test/uk/gov/hmrc/thirdpartydeveloperfrontend/controllers/AddApplicationProductionSwitchSpec.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.apiplatform.modules.uplift.services.GetProductionCredentialsF
 import uk.gov.hmrc.apiplatform.modules.uplift.services.mocks.UpliftLogicMock
 import uk.gov.hmrc.apiplatform.modules.uplift.views.html.BeforeYouStartView
 import uk.gov.hmrc.thirdpartydeveloperfrontend.builder.{DeveloperBuilder, _}
-import uk.gov.hmrc.thirdpartydeveloperfrontend.config.{ErrorHandler, UpliftJourneyConfig}
+import uk.gov.hmrc.thirdpartydeveloperfrontend.config.{ErrorHandler, Off, UpliftJourneyConfig}
 import uk.gov.hmrc.thirdpartydeveloperfrontend.controllers.addapplication.AddApplication
 import uk.gov.hmrc.thirdpartydeveloperfrontend.domain.models.controllers.ApplicationSummary
 import uk.gov.hmrc.thirdpartydeveloperfrontend.mocks.connectors.ApmConnectorMockModule
@@ -119,6 +119,7 @@ class AddApplicationProductionSwitchSpec
 
     when(appConfig.nameOfPrincipalEnvironment).thenReturn("Production")
     when(appConfig.nameOfSubordinateEnvironment).thenReturn("Sandbox")
+    when(mockUpliftJourneyConfig.status).thenReturn(Off)
 
     def shouldShowWhichAppMessage()(implicit results: Future[Result]) = {
       contentAsString(results) should include("Which application do you want production credentials for?")

--- a/test/uk/gov/hmrc/thirdpartydeveloperfrontend/controllers/AddApplicationStartSpec.scala
+++ b/test/uk/gov/hmrc/thirdpartydeveloperfrontend/controllers/AddApplicationStartSpec.scala
@@ -117,6 +117,7 @@ class AddApplicationStartSpec
     "return the add applications page with the user logged in when the environment is Production" in new Setup {
       when(appConfig.nameOfPrincipalEnvironment).thenReturn("Production")
       when(appConfig.nameOfSubordinateEnvironment).thenReturn("Sandbox")
+      when(upliftJourneyConfigMock.status).thenReturn(Off)
 
       private val result = underTest.addApplicationSubordinate()(loggedInRequest)
 
@@ -160,6 +161,8 @@ class AddApplicationStartSpec
     "return the add applications page with the user logged in when the environment is Production" in new Setup {
       when(appConfig.nameOfPrincipalEnvironment).thenReturn("Production")
       when(appConfig.nameOfSubordinateEnvironment).thenReturn("Sandbox")
+      when(upliftJourneyConfigMock.status).thenReturn(Off)
+
       private val result = underTest.addApplicationPrincipal()(loggedInRequest)
 
       status(result) shouldBe OK
@@ -173,6 +176,8 @@ class AddApplicationStartSpec
     "return the add applications page with the user logged in when the environment is QA" in new Setup {
       when(appConfig.nameOfPrincipalEnvironment).thenReturn("QA")
       when(appConfig.nameOfSubordinateEnvironment).thenReturn("Development")
+      when(upliftJourneyConfigMock.status).thenReturn(Off)
+
       private val result = underTest.addApplicationPrincipal()(loggedInRequest)
 
       status(result) shouldBe OK
@@ -219,26 +224,27 @@ class AddApplicationStartSpec
       }
 
     "return the add applications page when the UpliftJourneyConfig " +
-      "returns OnDemand and request header does not contain the uplift journey flag" in new Setup {
+      "returns OnDemand and request header does contain the old uplift journey flag" in new Setup {
         when(appConfig.nameOfPrincipalEnvironment).thenReturn("QA")
         when(appConfig.nameOfSubordinateEnvironment).thenReturn("Development")
 
         when(upliftJourneyConfigMock.status).thenReturn(OnDemand)
+        val loggedInRequestWithFlag = loggedInRequest.withHeaders(Headers("useOldUpliftJourney" -> "true"))
 
-        private val result = underTest.addApplicationPrincipal()(loggedInRequest)
+        private val result = underTest.addApplicationPrincipal()(loggedInRequestWithFlag)
 
         status(result) shouldBe OK
         contentAsString(result) should include("Add an application to QA")
       }
 
     "return the add applications page when the UpliftJourneyConfig " +
-      "returns OnDemand and request header contains the uplift journey flag set to false" in new Setup {
+      "returns OnDemand and request header contains the old uplift journey flag set to true" in new Setup {
         when(appConfig.nameOfPrincipalEnvironment).thenReturn("QA")
         when(appConfig.nameOfSubordinateEnvironment).thenReturn("Development")
 
         when(upliftJourneyConfigMock.status).thenReturn(OnDemand)
 
-        val loggedInRequestWithFlag = loggedInRequest.withHeaders(Headers("useNewUpliftJourney" -> "false"))
+        val loggedInRequestWithFlag = loggedInRequest.withHeaders(Headers("useOldUpliftJourney" -> "true"))
 
         private val result = underTest.addApplicationPrincipal()(loggedInRequestWithFlag)
 
@@ -247,7 +253,7 @@ class AddApplicationStartSpec
       }
 
     "return the uplift journey 'before you start' page when the UpliftJourneyConfig " +
-      "returns OnDemand and request header contains the uplift journey flag set to true" in new Setup {
+      "returns OnDemand and request header contains the old uplift journey flag set to false" in new Setup {
         when(appConfig.nameOfPrincipalEnvironment).thenReturn("QA")
         when(appConfig.nameOfSubordinateEnvironment).thenReturn("Development")
         when(flowServiceMock.resetFlow(*)).thenReturn(Future.successful(GetProductionCredentialsFlow("", None, None)))
@@ -258,7 +264,7 @@ class AddApplicationStartSpec
 
         when(upliftJourneyConfigMock.status).thenReturn(OnDemand)
 
-        val loggedInRequestWithFlag = loggedInRequest.withHeaders(Headers("useNewUpliftJourney" -> "true"))
+        val loggedInRequestWithFlag = loggedInRequest.withHeaders(Headers("useOldUpliftJourney" -> "false"))
 
         private val result = underTest.addApplicationPrincipal()(loggedInRequestWithFlag)
 
@@ -267,13 +273,13 @@ class AddApplicationStartSpec
       }
 
     "return the add applications page when the UpliftJourneyConfig " +
-      "returns Off and request header contains the uplift journey flag set to true" in new Setup {
+      "returns Off and request header contains the old uplift journey flag set to false" in new Setup {
         when(appConfig.nameOfPrincipalEnvironment).thenReturn("QA")
         when(appConfig.nameOfSubordinateEnvironment).thenReturn("Development")
 
         when(upliftJourneyConfigMock.status).thenReturn(Off)
 
-        val loggedInRequestWithFlag = loggedInRequest.withHeaders(Headers("useNewUpliftJourney" -> "true"))
+        val loggedInRequestWithFlag = loggedInRequest.withHeaders(Headers("useOldUpliftJourney" -> "false"))
 
         private val result = underTest.addApplicationPrincipal()(loggedInRequestWithFlag)
 

--- a/test/uk/gov/hmrc/thirdpartydeveloperfrontend/controllers/ChooseApplicationToUpliftActionSpec.scala
+++ b/test/uk/gov/hmrc/thirdpartydeveloperfrontend/controllers/ChooseApplicationToUpliftActionSpec.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.apiplatform.modules.uplift.services.GetProductionCredentialsF
 import uk.gov.hmrc.apiplatform.modules.uplift.services.mocks._
 import uk.gov.hmrc.apiplatform.modules.uplift.views.html.BeforeYouStartView
 import uk.gov.hmrc.thirdpartydeveloperfrontend.builder.{ApplicationBuilder, DeveloperBuilder, _}
-import uk.gov.hmrc.thirdpartydeveloperfrontend.config.{ErrorHandler, UpliftJourneyConfig}
+import uk.gov.hmrc.thirdpartydeveloperfrontend.config.{ErrorHandler, Off, UpliftJourneyConfig}
 import uk.gov.hmrc.thirdpartydeveloperfrontend.controllers.addapplication.AddApplication
 import uk.gov.hmrc.thirdpartydeveloperfrontend.domain.models.controllers.ApplicationSummary
 import uk.gov.hmrc.thirdpartydeveloperfrontend.mocks.connectors.ApmConnectorMockModule
@@ -120,6 +120,7 @@ class ChooseApplicationToUpliftActionSpec
 
     when(appConfig.nameOfPrincipalEnvironment).thenReturn("Production")
     when(appConfig.nameOfSubordinateEnvironment).thenReturn("Sandbox")
+    when(mockUpliftJourneyConfig.status).thenReturn(Off)
 
     def shouldShowWhichAppMessage()(implicit results: Future[Result]) = {
       contentAsString(results) should include("Which application do you want production credentials for?")


### PR DESCRIPTION
If OnDemand is set for the value of canUseNewUpliftJourney, then TPDFE will default to the new prod creds journey.  
The old journey will be available by setting the header 'useOldUpliftJourney' to true.  This is to enable setting up of old journey applications for testing the new terms of use journey.