### PR TITLE
API-6786 - Add back in the hidden label in case no explicit label

### DIFF
--- a/app/uk/gov/hmrc/apiplatform/modules/submissions/views/QuestionView.scala.html
+++ b/app/uk/gov/hmrc/apiplatform/modules/submissions/views/QuestionView.scala.html
@@ -197,6 +197,13 @@
         <label id="question-label" class="govuk-label" for="question-@{question.id.value}-id">
           @{question.label.get.value}
         </label>
+      } else {
+          <!-- Below is needed for accessibility, it is hidden visually -->
+        <h1 class="govuk-visually-hidden">
+          <label id="question-label" class="govuk-label govuk-label--l" for="question-@{question.id.value}-id">
+          @pageHeading
+          </label>
+        </h1>
       }
       @if(question.hintText.isDefined) {
         @renderHint(question.hintText.get, question.id.value)


### PR DESCRIPTION
On text input questions we don't define a label if it would be the same as the wording of the question so we need a fallback for when we don't define it